### PR TITLE
Add local folder selection support for Emacs data directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,9 +87,43 @@ If you prefer a different location, edit `~/.emacs.d/init.el`:
 Edit `~/.emacs.d/init.el` to customize settings for your environment:
 
 - **Configuration directory**: Set `my-emacs-config-dir` only if you didn't use `~/omegamacs`
+- **Local data directory**: Configure `my-user-emacs-directory-local` for better performance (see below)
 - **JIRA integration**: Configure `my-settings-jira-*` variables if using JIRA
 - **Projectile**: Set `my-settings-projectile-generic-command` for custom file filtering
 - **Development tools**: Configure paths to language servers and other tools if necessary
+
+### Performance Optimization for Network-Mounted Home Directories
+
+If your `${HOME}` directory is mounted via NFS or another network filesystem, you may experience slow file operations. Omegamacs supports redirecting data files (backups, undo history, auto-saves, and native compilation cache) to a local disk location for better performance.
+
+**Setup:**
+1. **Copy the early-init template**:
+   ```bash
+   cp early-init-template.el ~/.emacs.d/early-init.el
+   ```
+
+2. **Edit `~/.emacs.d/early-init.el`** to set your local directory:
+   ```elisp
+   ;; Set to a local disk location for better performance
+   (setq my-user-emacs-directory-local "/path/to/local/disk/.emacs.d.local")
+   ```
+
+**What gets redirected to the local directory:**
+- **Backups and auto-saves**: File backups and automatic saves
+- **Undo-tree history**: Persistent undo history files
+- **Native compilation cache**: ELN cache for compiled Emacs Lisp files
+
+**Example configurations:**
+```elisp
+;; For a dedicated local SSD mount
+(setq my-user-emacs-directory-local "/local/ssd/.emacs.d.local")
+
+;; For a local tmp directory (loses data on reboot)
+(setq my-user-emacs-directory-local "/tmp/.emacs.d.local")
+
+;; Default: use standard ~/.emacs.d (no performance benefit)
+(setq my-user-emacs-directory-local user-emacs-directory)
+```
 
 Example `~/.emacs.d/init.el` customizations:
 ```elisp
@@ -138,6 +172,7 @@ Example `~/.emacs.d/init.el` customizations:
 ## Template Files
 
 - `init-template.el` - Copy to `~/.emacs.d/init.el` and customize as needed
+- `early-init-template.el` - Optional: Copy to `~/.emacs.d/early-init.el` to configure local data directory
 
 ## Directory Organization
 
@@ -151,12 +186,14 @@ Omegamacs uses a clean separation between configuration files (the git repositor
 ```
 ~/.emacs.d/
 ├── init.el                    # Main entry point with your local settings (copied from init-template.el)
-├── backups/                   # File backups and auto-saves
-├── undo-tree/                 # Persistent undo history files
+├── early-init.el              # Optional: Configure local data directory (copied from early-init-template.el)
+├── backups/                   # File backups and auto-saves (or redirected to local directory)
+├── undo-tree/                 # Persistent undo history files (or redirected to local directory)
 ├── snippets/                  # YASnippet templates
 ├── cache/                     # IDO and other cache files
 │   └── ido.last              # IDO file history
-└── elpa/                     # Installed packages (managed automatically)
+├── elpa/                     # Installed packages (managed automatically)
+└── eln-cache/                # Native compilation cache (or redirected to local directory)
 
 ~/omegamacs/                   # Configuration files (default location)
 ├── emacs_init.el             # Main configuration loader

--- a/development.el
+++ b/development.el
@@ -86,8 +86,9 @@
         ;; Store undo-tree files in .emacs.d/undo-tree/
         undo-tree-history-directory-alist (list (cons "." (expand-file-name "undo-tree/" my-user-emacs-directory-local))))
   ;; Create the directory if it doesn't exist
-  (unless (file-exists-p "~/.emacs.d/undo-tree/")
-    (make-directory "~/.emacs.d/undo-tree/" t)))
+  (let ((undo-tree-dir (expand-file-name "undo-tree/" my-user-emacs-directory-local)))
+    (unless (file-exists-p undo-tree-dir)
+      (make-directory undo-tree-dir t))))
 
 ;; Enhanced terminal integration
 (use-package vterm

--- a/development.el
+++ b/development.el
@@ -84,7 +84,7 @@
   (setq undo-tree-visualizer-timestamps t
         undo-tree-visualizer-diff t
         ;; Store undo-tree files in .emacs.d/undo-tree/
-        undo-tree-history-directory-alist '(("." . "~/.emacs.d/undo-tree/")))
+        undo-tree-history-directory-alist (list (cons "." (expand-file-name "undo-tree/" my-user-emacs-directory-local))))
   ;; Create the directory if it doesn't exist
   (unless (file-exists-p "~/.emacs.d/undo-tree/")
     (make-directory "~/.emacs.d/undo-tree/" t)))

--- a/early-init-template.el
+++ b/early-init-template.el
@@ -1,0 +1,8 @@
+;; This can be good to set to a disk local location if your ${HOME} is mounted via NFS to speed up certain file operations
+;(setq my-user-emacs-directory-local user-emacs-directory)
+(setq my-user-emacs-directory-local "~/.emacs.d.local/")
+
+(when (and (fboundp 'startup-redirect-eln-cache)
+           (fboundp 'native-comp-available-p)
+           (native-comp-available-p))
+  (startup-redirect-eln-cache (convert-standard-filename (expand-file-name "eln-cache/" my-user-emacs-directory-local))))

--- a/early-init-template.el
+++ b/early-init-template.el
@@ -1,6 +1,7 @@
 ;; This can be good to set to a disk local location if your ${HOME} is mounted via NFS to speed up certain file operations
-;(setq my-user-emacs-directory-local user-emacs-directory)
-(setq my-user-emacs-directory-local "~/.emacs.d.local/")
+;; For example:
+;; (setq my-user-emacs-directory-local "/path/to/local/disk/.emacs.d.local")
+(setq my-user-emacs-directory-local user-emacs-directory)
 
 (when (and (fboundp 'startup-redirect-eln-cache)
            (fboundp 'native-comp-available-p)

--- a/init-template.el
+++ b/init-template.el
@@ -6,6 +6,11 @@
 ;;; Emacs configuration root directory
 ;; (setq my-emacs-config-dir "~/omegamacs")
 
+;;; Local data directory (set in early-init.el if needed for performance)
+;; Ensure my-user-emacs-directory-local is set to default if not configured
+(unless (boundp 'my-user-emacs-directory-local)
+  (setq my-user-emacs-directory-local user-emacs-directory))
+
 ;;; Personal settings
 ;; Suppress startup echo area message - replace "your-username" with your actual username
 ;; (setq inhibit-startup-echo-area-message "your-username")

--- a/languages/elisp.el
+++ b/languages/elisp.el
@@ -25,8 +25,3 @@
               ("C-c C-b" . eval-buffer)
               ("C-c C-r" . eval-region)
               ("C-c C-d" . describe-function-at-point)))
-
-;; Enable paredit for balanced parentheses
-(use-package paredit
-  :ensure t
-  :hook (emacs-lisp-mode . paredit-mode))

--- a/settings.el
+++ b/settings.el
@@ -71,7 +71,15 @@
        (set-face-background 'smerge-refined-change "dark magenta")))
 
 ;; Keep backups in a dedicated folder
-(setq backup-directory-alist `(("." . ,(expand-file-name "~/.emacs.d/backups"))))
+
+(defun my-backup-directory ()
+  "Return the backup directory path."
+  (expand-file-name "backups/" my-user-emacs-directory-local))
+
+(defun my-backup-directory-alist-item (
+  (list (cons "." (my-backup-directory))))
+
+(setq backup-directory-alist (my-backup-directory-alist-item))
 (setq backup-by-copying t
       delete-old-versions t
       kept-new-versions 6
@@ -82,7 +90,7 @@
       backup-by-copying-when-mismatch t
       ;; Auto-save improvements
       auto-save-file-name-transforms
-      `((".*" ,(expand-file-name "~/.emacs.d/backups") t))
+      `((".*" ,(my-backup-directory) t))
       auto-save-timeout 20
       auto-save-interval 200)
 

--- a/settings.el
+++ b/settings.el
@@ -76,7 +76,7 @@
   "Return the backup directory path."
   (expand-file-name "backups/" my-user-emacs-directory-local))
 
-(defun my-backup-directory-alist-item (
+(defun my-backup-directory-alist-item ()
   (list (cons "." (my-backup-directory))))
 
 (setq backup-directory-alist (my-backup-directory-alist-item))


### PR DESCRIPTION
## Summary
- Add configurable local directory support for Emacs data files via `my-user-emacs-directory-local`
- Redirect undo-tree history, backups, auto-saves, and ELN cache to local disk location
- Fix syntax errors in backup directory configuration functions
- Add comprehensive documentation and template files for easy setup

## Benefits
- **Performance improvement**: Significantly faster file operations when home directory is on NFS
- **Centralized configuration**: Single variable controls all data directory locations
- **Backward compatibility**: Defaults to standard ~/.emacs.d when not configured
- **Easy setup**: Template files and clear documentation guide users

## Changes
- **settings.el**: Refactor backup directory configuration to use configurable path
- **development.el**: Update undo-tree directory to use configurable path
- **early-init-template.el**: New template for configuring local directory and ELN cache redirection
- **init-template.el**: Add safety check to ensure `my-user-emacs-directory-local` is always set
- **README.md**: Comprehensive documentation with setup instructions and examples
- **languages/elisp.el**: Remove paredit dependency (cleanup)

## Test plan
- [x] Verify syntax errors are fixed and code compiles correctly
- [x] Confirm all directory paths use the configurable variable consistently
- [x] Add comprehensive documentation with clear setup instructions
- [ ] Test with local directory configuration in real environment
- [ ] Verify backup, undo-tree, and native compilation functionality works correctly