### PR TITLE
Refactor directory management and improve package path handling

### DIFF
--- a/emacs_init.el
+++ b/emacs_init.el
@@ -30,6 +30,13 @@
                         (file-name-directory (or load-file-name buffer-file-name)))))
     (expand-file-name file-relative-path config-dir)))
 
+(defun my-user-emacs-subdirectory-local (subdir)
+  "Given a subdirectory name, return the path the the disk locak user directory, if the path does not exists, create it"
+  (let ((dir (expand-file-name subdir my-user-emacs-directory-local)))
+    (unless (file-exists-p dir)
+      (make-directory dir t))
+    dir))
+
 ;; Check for minimal config argument
 (defvar my-minimal-config (member "--minimal" command-line-args)
   "When non-nil, load only essential configuration.")

--- a/packages.el
+++ b/packages.el
@@ -1,5 +1,7 @@
 ;;; -*- lexical-binding: t -*-
 
+;; This works the first time but does not work on subsequent runs
+;; TODO: Investigate why
 ;; (setq package-user-dir (my-user-emacs-subdirectory-local "elpa"))
 
 (use-package package

--- a/packages.el
+++ b/packages.el
@@ -1,6 +1,6 @@
 ;;; -*- lexical-binding: t -*-
 
-(setq package-user-dir (my-user-emacs-subdirectory-local "elpa"))
+;; (setq package-user-dir (my-user-emacs-subdirectory-local "elpa"))
 
 (use-package package
   :config

--- a/packages.el
+++ b/packages.el
@@ -1,5 +1,7 @@
 ;;; -*- lexical-binding: t -*-
 
+(setq package-user-dir (my-user-emacs-subdirectory-local "elpa"))
+
 (use-package package
   :config
   ;; Add all major package archives

--- a/programming.el
+++ b/programming.el
@@ -95,6 +95,14 @@
         (typescript "https://github.com/tree-sitter/tree-sitter-typescript" "master" "typescript/src")
         (yaml "https://github.com/ikatyang/tree-sitter-yaml")))
 
+(defun my-compile-treesit-grammars ()
+  "Compile all tree-sitter grammars defined in `treesit-language-source-alist'."
+  (interactive)
+  (dolist (lang treesit-language-source-alist)
+    (let ((lang-name (car lang)))
+      (message "Compiling %s..." lang-name)
+      (treesit-install-language-grammar lang-name))))
+
 ;; Eval this to compile them all
 ;;(mapc #'treesit-install-language-grammar (mapcar #'car treesit-language-source-alist))
 
@@ -194,3 +202,16 @@
 (use-package dap-mode
   :ensure t
   :after lsp-mode)
+
+;;(use-package realgud
+;;  :ensure t
+;;  :after (lsp-mode dap-mode)
+;;  :config
+;;  ;; Use realgud for debugging
+;;  (setq realgud:display-buffer 'realgud:display-buffer-same-window)
+;;  (setq realgud:window-height 20)
+;;  (setq realgud:window-width 80))
+;;
+;;(use-package realgud-ipdb
+;;  :ensure t
+;;  :after realgud)

--- a/programming.el
+++ b/programming.el
@@ -49,12 +49,12 @@
 (use-package lsp-treemacs
   :ensure t
   :after (lsp-mode treemacs)
-  ;;:config
-  ;;(defun my-lsp-treemacs-symbols-auto ()
-  ;;  "Auto-open treemacs symbols for C/C++ files when LSP starts."
-  ;;  (when (and (or (derived-mode-p 'c-mode) (derived-mode-p 'c++-mode))
-  ;;             (lsp-workspaces))
-  ;;    (run-with-timer 1 nil #'lsp-treemacs-symbols)))
+  :config
+  (defun my-lsp-treemacs-symbols-auto ()
+    "Auto-open treemacs symbols for C/C++ files when LSP starts."
+    (when (and (or (derived-mode-p 'c-mode) (derived-mode-p 'c++-mode))
+               (lsp-workspaces))
+      (run-with-timer 1 nil #'lsp-treemacs-symbols)))
 
   :hook (lsp-mode . my-lsp-treemacs-symbols-auto)
   :commands lsp-treemacs-symbols)
@@ -97,14 +97,6 @@
         (typescript "https://github.com/tree-sitter/tree-sitter-typescript" "master" "typescript/src")
         (yaml "https://github.com/ikatyang/tree-sitter-yaml")))
 
-(defun my-compile-treesit-grammars ()
-  "Compile all tree-sitter grammars defined in `treesit-language-source-alist'."
-  (interactive)
-  (dolist (lang treesit-language-source-alist)
-    (let ((lang-name (car lang)))
-      (message "Compiling %s..." lang-name)
-      (treesit-install-language-grammar lang-name))))
-
 ;; Eval this to compile them all
 ;;(mapc #'treesit-install-language-grammar (mapcar #'car treesit-language-source-alist))
 
@@ -114,8 +106,8 @@
   (which-key-mode))
 
 ;; LSP performance optimizations
-(setq gc-cons-threshold 100000000)
-(setq read-process-output-max (* 1024 1024 4)) ;; 4 Mb
+;;(setq gc-cons-threshold 100000000)
+(setq read-process-output-max (* 1024 1024)) ;; 4 Mb
 
 ;; Yasnippet for code snippets
 (use-package yasnippet
@@ -203,16 +195,3 @@
 (use-package dap-mode
   :ensure t
   :after lsp-mode)
-
-;;(use-package realgud
-;;  :ensure t
-;;  :after (lsp-mode dap-mode)
-;;  :config
-;;  ;; Use realgud for debugging
-;;  (setq realgud:display-buffer 'realgud:display-buffer-same-window)
-;;  (setq realgud:window-height 20)
-;;  (setq realgud:window-width 80))
-;;
-;;(use-package realgud-ipdb
-;;  :ensure t
-;;  :after realgud)

--- a/programming.el
+++ b/programming.el
@@ -38,6 +38,8 @@
         lsp-enable-indentation nil
         lsp-enable-on-type-formatting nil)
 
+  (setq lsp-idle-delay 0.250)
+
   :commands lsp)
 
 (use-package lsp-ui
@@ -47,12 +49,12 @@
 (use-package lsp-treemacs
   :ensure t
   :after (lsp-mode treemacs)
-  :config
-  (defun my-lsp-treemacs-symbols-auto ()
-    "Auto-open treemacs symbols for C/C++ files when LSP starts."
-    (when (and (or (derived-mode-p 'c-mode) (derived-mode-p 'c++-mode))
-               (lsp-workspaces))
-      (run-with-timer 1 nil #'lsp-treemacs-symbols)))
+  ;;:config
+  ;;(defun my-lsp-treemacs-symbols-auto ()
+  ;;  "Auto-open treemacs symbols for C/C++ files when LSP starts."
+  ;;  (when (and (or (derived-mode-p 'c-mode) (derived-mode-p 'c++-mode))
+  ;;             (lsp-workspaces))
+  ;;    (run-with-timer 1 nil #'lsp-treemacs-symbols)))
 
   :hook (lsp-mode . my-lsp-treemacs-symbols-auto)
   :commands lsp-treemacs-symbols)
@@ -111,10 +113,9 @@
   :config
   (which-key-mode))
 
-;; For performance
-;; Commented out - conflicts with startup optimization in emacs_init.el
-;;(setq gc-cons-threshold 100000000)
-(setq read-process-output-max (* 1024 1024)) ;; 1mb
+;; LSP performance optimizations
+(setq gc-cons-threshold 100000000)
+(setq read-process-output-max (* 1024 1024 4)) ;; 4 Mb
 
 ;; Yasnippet for code snippets
 (use-package yasnippet

--- a/programming.el
+++ b/programming.el
@@ -38,8 +38,6 @@
         lsp-enable-indentation nil
         lsp-enable-on-type-formatting nil)
 
-  (setq lsp-idle-delay 0.250)
-
   :commands lsp)
 
 (use-package lsp-ui
@@ -105,9 +103,10 @@
   :config
   (which-key-mode))
 
-;; LSP performance optimizations
+;; For performance
+;; Commented out - conflicts with startup optimization in emacs_init.el
 ;;(setq gc-cons-threshold 100000000)
-(setq read-process-output-max (* 1024 1024)) ;; 4 Mb
+(setq read-process-output-max (* 1024 1024)) ;; 1mb
 
 ;; Yasnippet for code snippets
 (use-package yasnippet

--- a/settings.el
+++ b/settings.el
@@ -87,10 +87,6 @@
         auto-save-timeout 20
         auto-save-interval 200))
 
-;; Create backup directory if it doesn't exist
-(unless (file-directory-p (expand-file-name "~/.emacs.d/backups"))
-  (make-directory (expand-file-name "~/.emacs.d/backups") t))
-
 ;; Brows things in emacs
 (setq browse-url-browser-function 'eww-browse-url)
 

--- a/settings.el
+++ b/settings.el
@@ -72,27 +72,20 @@
 
 ;; Keep backups in a dedicated folder
 
-(defun my-backup-directory ()
-  "Return the backup directory path."
-  (expand-file-name "backups/" my-user-emacs-directory-local))
-
-(defun my-backup-directory-alist-item ()
-  (list (cons "." (my-backup-directory))))
-
-(setq backup-directory-alist (my-backup-directory-alist-item))
-(setq backup-by-copying t
-      delete-old-versions t
-      kept-new-versions 6
-      kept-old-versions 2
-      version-control t
-      ;; Security improvements
-      backup-by-copying-when-linked t
-      backup-by-copying-when-mismatch t
-      ;; Auto-save improvements
-      auto-save-file-name-transforms
-      `((".*" ,(my-backup-directory) t))
-      auto-save-timeout 20
-      auto-save-interval 200)
+(let ((backup-dir (my-user-emacs-subdirectory-local "backups")))
+  (setq backup-directory-alist (list (cons "." backup-dir))
+        backup-by-copying t
+        delete-old-versions t
+        kept-new-versions 6
+        kept-old-versions 2
+        version-control t
+        ;; Security improvements
+        backup-by-copying-when-linked t
+        backup-by-copying-when-mismatch t
+        ;; Auto-save improvements
+        auto-save-file-name-transforms (list (list ".*" backup-dir t))
+        auto-save-timeout 20
+        auto-save-interval 200))
 
 ;; Create backup directory if it doesn't exist
 (unless (file-directory-p (expand-file-name "~/.emacs.d/backups"))


### PR DESCRIPTION
## Summary
- Add new `my-user-emacs-subdirectory-local` helper function for automatic directory creation
- Refactor backup directory configuration to use the new helper function
- Experiment with relocating package directory (currently disabled due to runtime issues)

## Test plan
- [x] Verify backup directory is created automatically
- [x] Test that backup functionality works as expected
- [x] Confirm no regression in existing functionality
- [ ] Investigate package directory relocation issue for future work