### PR TITLE
Add YAML mode support

### DIFF
--- a/emacs_init.el
+++ b/emacs_init.el
@@ -80,6 +80,7 @@
     (load (my-get-fullpath "languages/latex"))
     (load (my-get-fullpath "languages/xml"))
     (load (my-get-fullpath "languages/elisp"))
+    (load (my-get-fullpath "languages/yaml"))
     (load (my-get-fullpath "compilation"))
     (load (my-get-fullpath "projectile"))
     (load (my-get-fullpath "magit"))

--- a/languages/yaml.el
+++ b/languages/yaml.el
@@ -1,0 +1,10 @@
+;;; -*- lexical-binding: t -*-
+
+;; YAML mode for editing YAML files
+(use-package yaml-mode
+  :ensure t
+  :mode ("\\.ya?ml\\'" . yaml-mode)
+  :config
+  (add-hook 'yaml-mode-hook
+            (lambda ()
+              (define-key yaml-mode-map "\C-m" 'newline-and-indent))))


### PR DESCRIPTION
## Summary
- Add `languages/yaml.el` with YAML mode configuration
- Includes file association for `.yaml` and `.yml` files  
- Configures proper indentation on Enter key

## Test plan
- [ ] YAML files open in yaml-mode
- [ ] Proper syntax highlighting for YAML syntax
- [ ] Enter key provides correct indentation