### PR TITLE
Change prefix from my- to omegamacs- throughout codebase

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -107,8 +107,8 @@ If your language uses an LSP server:
 ```
 
 ### Variable Naming
-- Use `my-` prefix for custom variables and functions
-- Use `my--` prefix for internal/private variables
+- Use `omegamacs-` prefix for custom variables and functions
+- Use `omegamacs--` prefix for internal/private variables
 - Be descriptive: `my-python-test-command` not `my-pytest`
 
 ## Testing Your Changes

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ cp ~/my-custom-emacs/templates/early-init.el ~/.emacs.d/early-init.el
 
 Edit `~/.emacs.d/init.el` and set:
 ```elisp
-(setq my-emacs-config-dir "~/my-custom-emacs")
+(setq omegamacs-emacs-config-dir "~/my-custom-emacs")
 ```
 
 ### Performance Optimization (Network-Mounted Home)
@@ -107,7 +107,7 @@ If your `$HOME` is on NFS or network storage, you may experience slow file opera
 
 Edit `~/.emacs.d/early-init.el` and set, for example:
 ```elisp
-(setq my-user-emacs-directory-local "/local/ssd/.emacs.d.local")
+(setq omegamacs-user-emacs-directory-local "/local/ssd/.emacs.d.local")
 ```
 
 This redirects backups, undo history, and native compilation cache to local storage.
@@ -234,7 +234,7 @@ Omegamacs includes Hydra menus for quick access to common operations. Hydras pro
 
 **Available Hydras:**
 - **Org-mode** (`C-c o`): Complete GTD workflow commands
-- **Additional menus**: Run `M-x my-list-hydras` to see all available hydras
+- **Additional menus**: Run `M-x omegamacs-list-hydras` to see all available hydras
 
 ## GitHub Copilot Integration
 
@@ -244,7 +244,7 @@ Optional AI-powered coding assistance using [copilot.el](https://github.com/copi
 
 ### Configuration Options
 
-Set `my-copilot-config` in `~/.emacs.d/init.el`:
+Set `omegamacs-copilot-config` in `~/.emacs.d/init.el`:
 
 - **`'none`** (default): No Copilot support
 - **`'setup`**: Minimal configuration for server installation and authentication
@@ -260,14 +260,14 @@ Set `my-copilot-config` in `~/.emacs.d/init.el`:
 1. **Enable Copilot**:
    ```elisp
    ;; In ~/.emacs.d/init.el
-   (setq my-copilot-config 'setup)
+   (setq omegamacs-copilot-config 'setup)
    ```
 
 2. **Install server**: `M-x copilot-install-server`
 3. **Authenticate**: `M-x copilot-login` (opens browser)
 4. **Upgrade to full config**
    ```elisp
-   (setq my-copilot-config 'full)
+   (setq omegamacs-copilot-config 'full)
    ```
 
 **Note:** Requires active GitHub Copilot subscription and Node.js 18+. For Node.js installation/upgrade, see [Node Version Manager (nvm)](https://github.com/nvm-sh/nvm) or [official Node.js downloads](https://nodejs.org/en/download/).
@@ -282,20 +282,20 @@ Set these variables in `~/.emacs.d/init.el` (examples available in `templates/in
 
 ```elisp
 ;; Control how many shell history commands to load
-(setq my-compile-mode-shell-history-size 100)  ; Default: 100 commands
+(setq omegamacs-compile-mode-shell-history-size 100)  ; Default: 100 commands
 ;; Options:
 ;; nil   - disable shell history integration
 ;; 0     - load full shell history
 ;; 1-N   - load N most recent commands
 
 ;; Optional: specify custom history file location
-(setq my-compile-mode-shell-history-file (getenv "HISTFILE"))
+(setq omegamacs-compile-mode-shell-history-file (getenv "HISTFILE"))
 ;; Or use a specific path:
-;; (setq my-compile-mode-shell-history-file "~/.bash_history")
+;; (setq omegamacs-compile-mode-shell-history-file "~/.bash_history")
 ```
 
 ### Features
-- **Auto-detection**: If `my-compile-mode-shell-history-file` is not set, Omegamacs tries to guess your history file based on your shell
+- **Auto-detection**: If `omegamacs-compile-mode-shell-history-file` is not set, Omegamacs tries to guess your history file based on your shell
 - **Smart loading**: Refreshes history every time you invoke compile mode (`C-q`)
 - **Navigation**: Use `M-p`/`M-n` in compile command prompt to browse shell history
 - **Recent first**: Most recent commands appear first in history navigation
@@ -341,21 +341,21 @@ Edit `~/.emacs.d/init.el` to customize for your environment:
 
 ```elisp
 ;; Configuration directory (only if not using ~/omegamacs)
-;; (setq my-emacs-config-dir "~/my-custom-location")
+;; (setq omegamacs-emacs-config-dir "~/my-custom-location")
 
 ;; Performance optimization for network home directories
-;; (setq my-user-emacs-directory-local "/local/ssd/.emacs.d.local")
+;; (setq omegamacs-user-emacs-directory-local "/local/ssd/.emacs.d.local")
 
 ;; GitHub Copilot integration
-;; (setq my-copilot-config 'setup)    ; 'none, 'setup, or 'full
+;; (setq omegamacs-copilot-config 'setup)    ; 'none, 'setup, or 'full
 
 ;; JIRA integration (optional)
-;; (setq my-settings-jira-url "https://company.atlassian.net"
-;;       my-settings-jira-username "username"
-;;       my-settings-jira-project "PROJECT")
+;; (setq omegamacs-settings-jira-url "https://company.atlassian.net"
+;;       omegamacs-settings-jira-username "username"
+;;       omegamacs-settings-jira-project "PROJECT")
 
 ;; Custom projectile file filtering
-;; (setq my-settings-projectile-generic-command
+;; (setq omegamacs-settings-projectile-generic-command
 ;;       "find . -type f -not -path '*/node_modules/*' -print0")
 ```
 
@@ -373,7 +373,7 @@ Omegamacs includes a comprehensive Getting Things Done (GTD) implementation usin
 - `C-c o c` - Quick capture (add items to inbox)
 - `C-c o a` - Main GTD dashboard agenda view
 - `C-c o r` - Refile items from inbox to appropriate locations
-- `M-x my-list-hydras` - View all available hydra menus
+- `M-x omegamacs-list-hydras` - View all available hydra menus
 
 ### GTD Workflow Structure
 

--- a/company.el
+++ b/company.el
@@ -27,7 +27,7 @@
 ;; Enhanced company UI with icons and better styling
 (use-package company-box
   :ensure t
-  :defer my-enable-lazy-loading
+  :defer omegamacs-enable-lazy-loading
   :hook (company-mode . company-box-mode)
   :config
   (setq company-box-icons-alist 'company-box-icons-all-the-icons

--- a/completion.el
+++ b/completion.el
@@ -28,7 +28,7 @@
   :init
   (savehist-mode)
   :config
-  (setq savehist-file (my-user-emacs-file-local "savehist" "cache")
+  (setq savehist-file (omegamacs-user-emacs-file-local "savehist" "cache")
         savehist-additional-variables '(search-ring regexp-search-ring)
         savehist-autosave-interval 60))
 
@@ -38,7 +38,7 @@
   :init
   (recentf-mode)
   :config
-  (setq recentf-save-file (my-user-emacs-file-local "recentf" "cache")
+  (setq recentf-save-file (omegamacs-user-emacs-file-local "recentf" "cache")
         recentf-max-saved-items 200
         recentf-max-menu-items 50
         recentf-exclude '("^\*trace" "^\*GTAGS" "^session\\..*" "^\*"
@@ -66,7 +66,7 @@
 ;; Consult - enhanced completion commands
 (use-package consult
   :ensure t
-  :defer my-enable-lazy-loading
+  :defer omegamacs-enable-lazy-loading
   :bind (;; Replace common ido bindings
          ("C-x b" . consult-buffer)                ; replaces ido-switch-buffer
          ("C-x C-b" . consult-buffer)              ; alternative buffer switching
@@ -105,7 +105,7 @@
 ;; Embark - act on completion targets
 (use-package embark
   :ensure t
-  :defer my-enable-lazy-loading
+  :defer omegamacs-enable-lazy-loading
   :bind (("C-." . embark-act)
          ("C-;" . embark-dwim)
          ("C-h B" . embark-bindings))
@@ -121,7 +121,7 @@
 ;; Embark-consult integration
 (use-package embark-consult
   :ensure t
-  :defer my-enable-lazy-loading
+  :defer omegamacs-enable-lazy-loading
   :hook (embark-collect-mode . consult-preview-at-point-mode))
 
 ;; Enhanced minibuffer behavior

--- a/copilot/copilot.el
+++ b/copilot/copilot.el
@@ -49,7 +49,7 @@
                (lambda () (derived-mode-p 'vterm-mode)))
 
   ;; Custom functions for better integration
-  (defun my-copilot-toggle ()
+  (defun omegamacs-copilot-toggle ()
     "Toggle Copilot mode on/off."
     (interactive)
     (if copilot-mode
@@ -60,7 +60,7 @@
         (copilot-mode 1)
         (message "Copilot enabled"))))
 
-  (defun my-copilot-complete-or-accept ()
+  (defun omegamacs-copilot-complete-or-accept ()
     "Accept Copilot suggestion or trigger completion if no suggestion."
     (interactive)
     (if (copilot--overlay-visible)
@@ -69,7 +69,7 @@
           (company-manual-begin)
         (completion-at-point))))
 
-  (defun my-copilot-accept-word-or-line ()
+  (defun omegamacs-copilot-accept-word-or-line ()
     "Accept Copilot suggestion by word, or full line if at end."
     (interactive)
     (if (copilot--overlay-visible)
@@ -79,7 +79,7 @@
       (message "No Copilot suggestion available")))
 
   ;; Global keybindings for Copilot control
-  (global-set-key (kbd "C-c c t") 'my-copilot-toggle)
+  (global-set-key (kbd "C-c c t") 'omegamacs-copilot-toggle)
   (global-set-key (kbd "C-c c c") 'copilot-complete)
   (global-set-key (kbd "C-c c d") 'copilot-diagnose)
   (global-set-key (kbd "C-c c l") 'copilot-login)
@@ -89,7 +89,7 @@
   (add-to-list 'copilot-indentation-alist '(emacs-lisp-mode 2))
 
   ;; Enhanced TAB behavior that works with indentation
-  (defun my-copilot-tab-or-indent ()
+  (defun omegamacs-copilot-tab-or-indent ()
     "Accept Copilot completion or indent line."
     (interactive)
     (if (copilot--overlay-visible)
@@ -97,11 +97,11 @@
       (indent-for-tab-command)))
 
   ;; Override TAB in programming modes
-  (define-key prog-mode-map (kbd "<tab>") 'my-copilot-tab-or-indent)
-  (define-key prog-mode-map (kbd "TAB") 'my-copilot-tab-or-indent)
+  (define-key prog-mode-map (kbd "<tab>") 'omegamacs-copilot-tab-or-indent)
+  (define-key prog-mode-map (kbd "TAB") 'omegamacs-copilot-tab-or-indent)
 
   ;; Mode line indicator
-  (defun my--copilot-mode-line ()
+  (defun omegamacs--copilot-mode-line ()
     "Return mode line string for Copilot status."
     (when copilot-mode
       (if (copilot--overlay-visible)
@@ -109,7 +109,7 @@
         " Co")))
 
   ;; Add to mode line
-  (add-to-list 'mode-line-misc-info '(:eval (my--copilot-mode-line)))
+  (add-to-list 'mode-line-misc-info '(:eval (omegamacs--copilot-mode-line)))
 
   ;; Advice to improve interaction with other completion systems
   (advice-add 'copilot-accept-completion :around
@@ -131,7 +131,7 @@
    '(copilot-overlay-face ((t (:foreground "#6272A4" :italic t)))))
 
   ;; Diagnostic function for troubleshooting
-  (defun my-copilot-status ()
+  (defun omegamacs-copilot-status ()
     "Show detailed Copilot status information."
     (interactive)
     (message "Copilot mode: %s | Logged in: %s | Version: %s | Node.js: %s"
@@ -140,4 +140,4 @@
              (or copilot-version "unknown")
              (or copilot--node-executable "not found")))
 
-  (global-set-key (kbd "C-c c i") 'my-copilot-status))
+  (global-set-key (kbd "C-c c i") 'omegamacs-copilot-status))

--- a/development.el
+++ b/development.el
@@ -36,7 +36,7 @@
 
 (use-package dired-subtree
   :ensure t
-  :defer my-enable-lazy-loading
+  :defer omegamacs-enable-lazy-loading
   :bind (:map dired-mode-map
          ("<tab>" . dired-subtree-toggle)
          ("<backtab>" . dired-subtree-cycle)))
@@ -44,13 +44,13 @@
 ;; Enhanced programming modes
 (use-package rainbow-delimiters
   :ensure t
-  :defer my-enable-lazy-loading
+  :defer omegamacs-enable-lazy-loading
   :hook (prog-mode . rainbow-delimiters-mode)
   :config (setq sp-autoinsert-pair nil))
 
 (use-package smartparens
   :ensure t
-  :defer my-enable-lazy-loading
+  :defer omegamacs-enable-lazy-loading
   :hook (prog-mode . smartparens-mode)
   :config
   (require 'smartparens-config))
@@ -58,7 +58,7 @@
 ;; Better editing with multiple cursors
 (use-package multiple-cursors
   :ensure t
-  :defer my-enable-lazy-loading
+  :defer omegamacs-enable-lazy-loading
   :bind (("C-S-c C-S-c" . mc/edit-lines)
          ("C->" . mc/mark-next-like-this)
          ("C-<" . mc/mark-previous-like-this)
@@ -80,16 +80,16 @@
   (setq undo-tree-visualizer-timestamps t
         undo-tree-visualizer-diff t
         ;; Store undo-tree files in .emacs.d/undo-tree/
-        undo-tree-history-directory-alist (list (cons "." (expand-file-name "undo-tree/" my-user-emacs-directory-local))))
+        undo-tree-history-directory-alist (list (cons "." (expand-file-name "undo-tree/" omegamacs-user-emacs-directory-local))))
   ;; Create the directory if it doesn't exist
-  (let ((undo-tree-dir (expand-file-name "undo-tree/" my-user-emacs-directory-local)))
+  (let ((undo-tree-dir (expand-file-name "undo-tree/" omegamacs-user-emacs-directory-local)))
     (unless (file-exists-p undo-tree-dir)
       (make-directory undo-tree-dir t))))
 
 ;; Enhanced terminal integration
 (use-package vterm
   :ensure t
-  :defer my-enable-lazy-loading
+  :defer omegamacs-enable-lazy-loading
   :commands (vterm vterm-other-window)
   :config
   (setq vterm-max-scrollback 10000))
@@ -108,5 +108,5 @@
 ;; Hide comments temporarily to focus on code structure
 (use-package nocomments-mode
   :ensure t
-  :defer my-enable-lazy-loading
+  :defer omegamacs-enable-lazy-loading
   :bind (("<f12>" . nocomments-mode)))

--- a/emacs_init.el
+++ b/emacs_init.el
@@ -1,8 +1,8 @@
 ;;; -*- lexical-binding: t -*-
 
-(defvar my--gc-cons-threshold gc-cons-threshold)
-(defvar my--gc-cons-percentage gc-cons-percentage)
-(defvar my--file-name-handler-alist file-name-handler-alist)
+(defvar omegamacs--gc-cons-threshold gc-cons-threshold)
+(defvar omegamacs--gc-cons-percentage gc-cons-percentage)
+(defvar omegamacs--file-name-handler-alist file-name-handler-alist)
 
 ;; Maximize memory during startup for better performance
 (setq gc-cons-threshold most-positive-fixnum
@@ -18,37 +18,37 @@
 ;; Restore normal values after startup
 (add-hook 'emacs-startup-hook
           (lambda ()
-            (setq gc-cons-threshold my--gc-cons-threshold
-                  gc-cons-percentage my--gc-cons-percentage
-                  file-name-handler-alist my--file-name-handler-alist)
+            (setq gc-cons-threshold omegamacs--gc-cons-threshold
+                  gc-cons-percentage omegamacs--gc-cons-percentage
+                  file-name-handler-alist omegamacs--file-name-handler-alist)
             ;; Optional: run gc after startup
             (garbage-collect)))
 
-(defun my-get-fullpath (file-relative-path)
+(defun omegamacs-get-fullpath (file-relative-path)
   "Return the full path of FILE-RELATIVE-PATH, relative to the configuration directory."
-  (let ((config-dir (or (and (boundp 'my-emacs-config-dir) my-emacs-config-dir)
+  (let ((config-dir (or (and (boundp 'omegamacs-emacs-config-dir) omegamacs-emacs-config-dir)
                         (file-name-directory (or load-file-name buffer-file-name)))))
     (expand-file-name file-relative-path config-dir)))
 
-(defun my-user-emacs-subdirectory-local (subdir)
+(defun omegamacs-user-emacs-subdirectory-local (subdir)
   "Given a subdirectory name, return the path to the disk local user directory; if the path does not exist, create it."
-  (let ((dir (expand-file-name subdir my-user-emacs-directory-local)))
+  (let ((dir (expand-file-name subdir omegamacs-user-emacs-directory-local)))
     (unless (file-exists-p dir)
       (make-directory dir t))
     dir))
 
-(defun my-user-emacs-file-local (file-name &optional subdir)
+(defun omegamacs-user-emacs-file-local (file-name &optional subdir)
   "Given name, return the path to the disk local user directory; if the path does not exist, create it."
   (let ((dir (if subdir
-                 (my-user-emacs-subdirectory-local subdir)
-               my-user-emacs-directory-local)))
+                 (omegamacs-user-emacs-subdirectory-local subdir)
+               omegamacs-user-emacs-directory-local)))
     (let ((fn (expand-file-name file-name dir)))
       (unless (file-exists-p fn)
         (with-temp-buffer
           (write-file fn)))
       fn)))
 
-(defun my-user-emacs-subdirectory (subdir)
+(defun omegamacs-user-emacs-subdirectory (subdir)
   "Given a subdirectory name, return the path to the directorey directory; if the path does not exist, create it."
   (let ((dir (expand-file-name subdir user-emacs-directory)))
     (unless (file-exists-p dir)
@@ -56,11 +56,11 @@
     dir))
 
 ;; Check for minimal config argument
-(defvar my-minimal-config (member "--minimal" command-line-args)
+(defvar omegamacs-minimal-config (member "--minimal" command-line-args)
   "When non-nil, load only essential configuration.")
 
 ;; Check for no-defer argument
-(defvar my-enable-lazy-loading (not (member "--no-defer" command-line-args))
+(defvar omegamacs-enable-lazy-loading (not (member "--no-defer" command-line-args))
   "When non-nil, enable lazy loading with :defer. Set to nil for immediate loading of all packages.")
 
 ;; Remove the arguments so they don't cause issues
@@ -69,41 +69,41 @@
 
 ;; Show startup mode information
 (message "Omegamacs startup: %s mode, lazy loading %s" 
-         (if my-minimal-config "minimal" "full")
-         (if my-enable-lazy-loading "enabled" "disabled"))
+         (if omegamacs-minimal-config "minimal" "full")
+         (if omegamacs-enable-lazy-loading "enabled" "disabled"))
 
-(if my-minimal-config
-    (load (my-get-fullpath "minimal"))
+(if omegamacs-minimal-config
+    (load (omegamacs-get-fullpath "minimal"))
   (progn
     ;; Full configuration
-    (load (my-get-fullpath "packages"))
-    (load (my-get-fullpath "hydra"))
-    (load (my-get-fullpath "settings"))
-    (load (my-get-fullpath "flycheck"))
-    (load (my-get-fullpath "company"))
-    (load (my-get-fullpath "completion"))
-    (load (my-get-fullpath "frame_buffer_handling"))
-    (load (my-get-fullpath "programming"))
-    (load (my-get-fullpath "languages/cpp"))
-    (load (my-get-fullpath "languages/python"))
-    (load (my-get-fullpath "languages/verilog"))
-    (load (my-get-fullpath "languages/latex"))
-    (load (my-get-fullpath "languages/xml"))
-    (load (my-get-fullpath "languages/elisp"))
-    (load (my-get-fullpath "languages/yaml"))
-    (load (my-get-fullpath "compilation"))
-    (load (my-get-fullpath "projectile"))
-    (load (my-get-fullpath "magit"))
-    (load (my-get-fullpath "tramp"))
-    (load (my-get-fullpath "development"))
-    (load (my-get-fullpath "org"))
+    (load (omegamacs-get-fullpath "packages"))
+    (load (omegamacs-get-fullpath "hydra"))
+    (load (omegamacs-get-fullpath "settings"))
+    (load (omegamacs-get-fullpath "flycheck"))
+    (load (omegamacs-get-fullpath "company"))
+    (load (omegamacs-get-fullpath "completion"))
+    (load (omegamacs-get-fullpath "frame_buffer_handling"))
+    (load (omegamacs-get-fullpath "programming"))
+    (load (omegamacs-get-fullpath "languages/cpp"))
+    (load (omegamacs-get-fullpath "languages/python"))
+    (load (omegamacs-get-fullpath "languages/verilog"))
+    (load (omegamacs-get-fullpath "languages/latex"))
+    (load (omegamacs-get-fullpath "languages/xml"))
+    (load (omegamacs-get-fullpath "languages/elisp"))
+    (load (omegamacs-get-fullpath "languages/yaml"))
+    (load (omegamacs-get-fullpath "compilation"))
+    (load (omegamacs-get-fullpath "projectile"))
+    (load (omegamacs-get-fullpath "magit"))
+    (load (omegamacs-get-fullpath "tramp"))
+    (load (omegamacs-get-fullpath "development"))
+    (load (omegamacs-get-fullpath "org"))
     ;; Load Copilot configuration based on user preference
-    (when (boundp 'my-copilot-config)
+    (when (boundp 'omegamacs-copilot-config)
       (cond
-       ((eq my-copilot-config 'setup)
-        (load (my-get-fullpath "copilot/copilot-setup")))
-       ((eq my-copilot-config 'full)
-        (load (my-get-fullpath "copilot/copilot")))))
+       ((eq omegamacs-copilot-config 'setup)
+        (load (omegamacs-get-fullpath "copilot/copilot-setup")))
+       ((eq omegamacs-copilot-config 'full)
+        (load (omegamacs-get-fullpath "copilot/copilot")))))
     ))
 
 (setq fill-column 140)
@@ -112,8 +112,8 @@
 (setq custom-file (expand-file-name "custom.el" user-emacs-directory))
 
 ;; Convenient reload function
-(defun my-reload-config ()
+(defun omegamacs-reload-config ()
   "Reload the entire Emacs configuration."
   (interactive)
-  (load-file (my-get-fullpath "emacs_init.el"))
+  (load-file (omegamacs-get-fullpath "emacs_init.el"))
   (message "Configuration reloaded!"))

--- a/hydra.el
+++ b/hydra.el
@@ -4,7 +4,7 @@
 (use-package hydra
   :ensure t
   :config
-  (defun my-list-hydras ()
+  (defun omegamacs-list-hydras ()
     "List all defined hydras (functions ending with /body) in a *Hydras* buffer.
 Shows the hydra name, any bound keys, and the docstring (first line)."
     (interactive)

--- a/languages/cpp.el
+++ b/languages/cpp.el
@@ -13,7 +13,7 @@
         c-basic-offset 4)
 
   ;; Custom indentation rules
-  (c-add-style "my-c-style"
+  (c-add-style "omegamacs-c-style"
                '("linux"
                  (c-offsets-alist
                   (innamespace . 0)           ; No indentation for namespace contents
@@ -27,19 +27,19 @@
   ;; Apply the style to C/C++ modes
   (add-hook 'c-mode-hook
             (lambda ()
-              (c-set-style "my-c-style")))
+              (c-set-style "omegamacs-c-style")))
   (add-hook 'c++-mode-hook
             (lambda ()
-              (c-set-style "my-c-style"))))
+              (c-set-style "omegamacs-c-style"))))
 
 (use-package flycheck-clang-tidy
   :ensure t
-  :defer my-enable-lazy-loading
+  :defer omegamacs-enable-lazy-loading
   :hook (flycheck-mode . flycheck-clang-tidy-setup))
 
 (use-package flycheck-clang-analyzer
   :ensure t
-  :defer my-enable-lazy-loading
+  :defer omegamacs-enable-lazy-loading
   :hook (flycheck-mode . flycheck-clang-analyzer-setup))
 
 (with-eval-after-load 'lsp-mode
@@ -48,5 +48,5 @@
 
 (use-package bison-mode
   :ensure t
-  :defer my-enable-lazy-loading
+  :defer omegamacs-enable-lazy-loading
   :mode ("\\.yy?\\'" "\\.ll?\\'"))

--- a/languages/latex.el
+++ b/languages/latex.el
@@ -5,7 +5,7 @@
 ;; AUCTeX - The premier LaTeX mode for Emacs
 (use-package auctex
   :ensure t
-  :defer my-enable-lazy-loading
+  :defer omegamacs-enable-lazy-loading
   :mode ("\\.tex\\'" . LaTeX-mode)
   :config
   ;; Basic AUCTeX settings
@@ -39,7 +39,7 @@
 ;; RefTeX for references, citations, and labels
 (use-package reftex
   :ensure t
-  :defer my-enable-lazy-loading
+  :defer omegamacs-enable-lazy-loading
   :hook (LaTeX-mode . reftex-mode)
   :config
   ;; RefTeX settings
@@ -51,7 +51,7 @@
 ;; Company completion for LaTeX
 (use-package company-auctex
   :ensure t
-  :defer my-enable-lazy-loading
+  :defer omegamacs-enable-lazy-loading
   :after (company auctex)
   :config
   (company-auctex-init))
@@ -59,7 +59,7 @@
 ;; Math input improvements
 (use-package cdlatex
   :ensure t
-  :defer my-enable-lazy-loading
+  :defer omegamacs-enable-lazy-loading
   :hook (LaTeX-mode . cdlatex-mode)
   :config
   ;; Use TAB for cdlatex in LaTeX mode
@@ -81,13 +81,13 @@
 ;;                    :server-id 'texlab))
 ;;
 ;;  ;; Auto-start lsp for LaTeX if texlab is available
-;;  (defun my-latex-lsp-ensure ()
+;;  (defun omegamacs-latex-lsp-ensure ()
 ;;    "Start lsp for LaTeX only if texlab is available."
 ;;    (when (executable-find "texlab")
 ;;      (lsp-deferred)))
 ;;
-;;  (add-hook 'LaTeX-mode-hook 'my-latex-lsp-ensure)
-;;  (add-hook 'latex-mode-hook 'my-latex-lsp-ensure))
+;;  (add-hook 'LaTeX-mode-hook 'omegamacs-latex-lsp-ensure)
+;;  (add-hook 'latex-mode-hook 'omegamacs-latex-lsp-ensure))
 
 ;; Preview support
 (use-package preview

--- a/languages/python.el
+++ b/languages/python.el
@@ -17,7 +17,7 @@
                `(python-ts-mode . ("pyright-langserver" "--stdio")))
 
   ;; Enhanced auto-start function with better error handling
-  (defun my--python-eglot-ensure ()
+  (defun omegamacs--python-eglot-ensure ()
     "Start eglot for Python with error handling."
     (when (and (executable-find "pyright-langserver")
                (not (eglot-current-server)))
@@ -27,17 +27,17 @@
          (message "Eglot failed to start: %s" (error-message-string err))))))
 
   ;; Manual eglot commands for debugging
-  (defun my-eglot-restart ()
+  (defun omegamacs-eglot-restart ()
     "Restart eglot server for current buffer."
     (interactive)
     (when (eglot-current-server)
       (eglot-shutdown (eglot-current-server)))
     (eglot-ensure))
 
-  :hook ((python-mode . my--python-eglot-ensure)
-         (python-ts-mode . my--python-eglot-ensure))
+  :hook ((python-mode . omegamacs--python-eglot-ensure)
+         (python-ts-mode . omegamacs--python-eglot-ensure))
   :bind (:map python-mode-map
-         ("C-c l r" . my-eglot-restart)
+         ("C-c l r" . omegamacs-eglot-restart)
          ("C-c l s" . eglot)))
 
 ;; Enable eglot breadcrumbs for managed buffers
@@ -51,5 +51,5 @@
 ;; Lark grammar files support
 (use-package lark-mode
   :ensure t
-  :defer my-enable-lazy-loading
+  :defer omegamacs-enable-lazy-loading
   :mode "\\.lark\\'")

--- a/languages/verilog.el
+++ b/languages/verilog.el
@@ -2,7 +2,7 @@
 ;;; Verilog Language Configuration
 
 ;; Shared Verilog configuration with performance optimizations
-(defun my-setup-verilog-indent ()
+(defun omegamacs-setup-verilog-indent ()
   "Configure Verilog indentation settings."
   (message "VERILOG MODE SETUP")
   (setq verilog-indent-level              4
@@ -29,18 +29,18 @@
 
 (use-package verilog-ts-mode
   :ensure t
-  :defer my-enable-lazy-loading
-  :hook (verilog-ts-mode . my-setup-verilog-indent))
+  :defer omegamacs-enable-lazy-loading
+  :hook (verilog-ts-mode . omegamacs-setup-verilog-indent))
 
 (use-package verilog-mode
   :ensure t
-  :defer my-enable-lazy-loading
-  :hook (verilog-mode . my-setup-verilog-indent))
+  :defer omegamacs-enable-lazy-loading
+  :hook (verilog-mode . omegamacs-setup-verilog-indent))
 
 ;; https://github.com/gmlarumbe/verilog-ext
 (use-package verilog-ext
   :ensure t
-  :defer my-enable-lazy-loading
+  :defer omegamacs-enable-lazy-loading
   :hook ((verilog-ts-mode . verilog-ext-mode)
          (verilog-mode . verilog-ext-mode))
   :init

--- a/languages/yaml.el
+++ b/languages/yaml.el
@@ -3,7 +3,7 @@
 ;; YAML mode for editing YAML files
 (use-package yaml-mode
   :ensure t
-  :defer my-enable-lazy-loading
+  :defer omegamacs-enable-lazy-loading
   :mode ("\\.ya?ml\\'" . yaml-mode)
   :config
   (add-hook 'yaml-mode-hook

--- a/magit.el
+++ b/magit.el
@@ -29,7 +29,7 @@
 ;; For initial setup see https://magit.vc/manual/forge/Initial-Setup.html
 (use-package forge
   :ensure t
-  :defer my-enable-lazy-loading
+  :defer omegamacs-enable-lazy-loading
   :after magit)
 
 (defhydra hydra-git (:color teal :hint nil)

--- a/minimal.el
+++ b/minimal.el
@@ -1,7 +1,7 @@
 ;;; -*- lexical-binding: t -*-
 
 ;; Load only essential settings
-(load (my-get-fullpath "settings"))
+(load (omegamacs-get-fullpath "settings"))
 
 (windmove-default-keybindings)
 

--- a/org.el
+++ b/org.el
@@ -3,25 +3,25 @@
 (use-package org
   :ensure t
   :pin gnu
-  :defer my-enable-lazy-loading
+  :defer omegamacs-enable-lazy-loading
   :bind ("C-c o" . hydra-org/body)
   :mode ("\.org\'" . org-mode)
   :init
   ;; Org files should be accessible from $HOME in general
-  (setq my--org-dir (my-user-emacs-subdirectory "org")
-        my--org-file-inbox (expand-file-name "inbox.org" my--org-dir)
-        my--org-file-projects (expand-file-name "projects.org" my--org-dir)
-        my--org-file-next (expand-file-name "next.org" my--org-dir)
-        my--org-file-someday (expand-file-name "someday.org" my--org-dir)
-        my--org-file-journal (expand-file-name "journal.org" my--org-dir))
+  (setq omegamacs--org-dir (omegamacs-user-emacs-subdirectory "org")
+        omegamacs--org-file-inbox (expand-file-name "inbox.org" omegamacs--org-dir)
+        omegamacs--org-file-projects (expand-file-name "projects.org" omegamacs--org-dir)
+        omegamacs--org-file-next (expand-file-name "next.org" omegamacs--org-dir)
+        omegamacs--org-file-someday (expand-file-name "someday.org" omegamacs--org-dir)
+        omegamacs--org-file-journal (expand-file-name "journal.org" omegamacs--org-dir))
 
   ;; Where your GTD files live
-  (setq org-directory my--org-dir
-        org-agenda-files (list my--org-file-inbox
-                               my--org-file-projects
-                               my--org-file-next
-                               my--org-file-someday
-                               my--org-file-journal))
+  (setq org-directory omegamacs--org-dir
+        org-agenda-files (list omegamacs--org-file-inbox
+                               omegamacs--org-file-projects
+                               omegamacs--org-file-next
+                               omegamacs--org-file-someday
+                               omegamacs--org-file-journal))
 
   ;; [Claude] ensure that all org files exist
   (dolist (file org-agenda-files)
@@ -70,45 +70,45 @@
 
   ;; Refile: move items from inbox to project/next/someday
   (setq org-refile-targets
-     `((,my--org-file-projects :maxlevel . 3)
-       (,my--org-file-next     :maxlevel . 2)
-       (,my--org-file-someday  :maxlevel . 2)))
+     `((,omegamacs--org-file-projects :maxlevel . 3)
+       (,omegamacs--org-file-next     :maxlevel . 2)
+       (,omegamacs--org-file-someday  :maxlevel . 2)))
 
   (setq org-outline-path-complete-in-steps nil
         org-refile-use-outline-path 'file) ;; completion like: projects.org/Projects/…
 
   ;; Capture (C-c c)
-  (setq org-default-notes-file my--org-file-inbox)
+  (setq org-default-notes-file omegamacs--org-file-inbox)
   (setq org-capture-templates
         `(
           ;; Quick inbox task
           ("t" "Todo → Inbox" entry
-           (file+headline my--org-file-inbox "Inbox")
+           (file+headline omegamacs--org-file-inbox "Inbox")
            "* TODO %?\n:PROPERTIES:\n:Created: %U\n:END:\n%a\n" :empty-lines 1)
 
           ;; Next action to Next file
           ("n" "Next action" entry
-           (file my--org-file-next)
+           (file omegamacs--org-file-next)
            "* NEXT %? %^g\n%a\n" :empty-lines 1)
 
           ;; New project skeleton
           ("p" "Project" entry
-           (file+headline my--org-file-projects "Projects")
+           (file+headline omegamacs--org-file-projects "Projects")
            "* PROJECT %^{Project name}\n** NEXT %?\n" :empty-lines 1)
 
           ;; Someday/Maybe
           ("s" "Someday" entry
-           (file my--org-file-someday)
+           (file omegamacs--org-file-someday)
            "* TODO %? :someday:\n" :empty-lines 1)
 
           ;; Journal
           ("j" "Journal" entry
-           (file+datetree my--org-file-journal)
+           (file+datetree omegamacs--org-file-journal)
            "* %U %?\n%i\n" :empty-lines 1)
 
           ;; Meeting note + clocking
           ("m" "Meeting (clocked)" entry
-           (file+datetree my--org-file-journal)
+           (file+datetree omegamacs--org-file-journal)
            "* %^{Title}\n:PROPERTIES:\n:Participants: %^{Who}\n:END:\n%U\n%?\n"
            :clock-in t :clock-resume t :empty-lines 1)
           ))
@@ -235,7 +235,7 @@
 
 (use-package org-super-agenda
   :ensure t
-  :defer my-enable-lazy-loading
+  :defer omegamacs-enable-lazy-loading
   :after org
   :config
   (org-super-agenda-mode)

--- a/packages.el
+++ b/packages.el
@@ -2,7 +2,7 @@
 
 ;; This works the first time but does not work on subsequent runs
 ;; TODO: Investigate why
-;; (setq package-user-dir (my-user-emacs-subdirectory-local "elpa"))
+;; (setq package-user-dir (omegamacs-user-emacs-subdirectory-local "elpa"))
 
 (use-package package
   :config
@@ -33,7 +33,7 @@
 (when (getenv "EMACS_PACKAGE_UPDATE_ENABLE")
   (use-package auto-package-update
     :ensure t
-    :defer my-enable-lazy-loading
+    :defer omegamacs-enable-lazy-loading
     :config
     (setq auto-package-update-delete-old-versions t
           auto-package-update-interval 7)

--- a/programming.el
+++ b/programming.el
@@ -44,16 +44,16 @@
 
 (use-package lsp-ui
   :ensure t
-  :defer my-enable-lazy-loading
+  :defer omegamacs-enable-lazy-loading
   :commands lsp-ui-mode)
 
 (use-package lsp-treemacs
   :ensure t
-  :defer my-enable-lazy-loading
+  :defer omegamacs-enable-lazy-loading
   :after (lsp-mode treemacs)
   :config
   ;; Allow C-x 1 to work normally by removing no-delete-other-windows parameter
-  (defun my--delete-other-windows-advice (orig-fun &rest args)
+  (defun omegamacs--delete-other-windows-advice (orig-fun &rest args)
     "Allow C-x 1 (delete-other-windows) to work normally even when packages set no-delete-other-windows.
 
 Some packages (notably lsp-treemacs) set the 'no-delete-other-windows window parameter
@@ -75,21 +75,21 @@ Potential side effects:
       (set-window-parameter window 'no-delete-other-windows nil))
     (apply orig-fun args))
 
-  (advice-add 'delete-other-windows :around #'my--delete-other-windows-advice)
+  (advice-add 'delete-other-windows :around #'omegamacs--delete-other-windows-advice)
 
-  (defun my--lsp-treemacs-symbols-auto ()
+  (defun omegamacs--lsp-treemacs-symbols-auto ()
     "Auto-open treemacs symbols for C/C++ files when LSP starts."
     (when (and (or (derived-mode-p 'c-mode) (derived-mode-p 'c++-mode))
                (lsp-workspaces))
       (run-with-timer 1 nil #'lsp-treemacs-symbols)))
 
-  :hook (lsp-mode . my--lsp-treemacs-symbols-auto)
+  :hook (lsp-mode . omegamacs--lsp-treemacs-symbols-auto)
   :commands lsp-treemacs-symbols)
 
 ;; Use consult-lsp for LSP integration with Vertico
 (use-package consult-lsp
   :ensure t
-  :defer my-enable-lazy-loading
+  :defer omegamacs-enable-lazy-loading
   :after (lsp-mode consult)
   :bind (:map lsp-mode-map
          ([remap xref-find-apropos] . consult-lsp-symbols)))
@@ -124,7 +124,7 @@ Potential side effects:
         (typescript "https://github.com/tree-sitter/tree-sitter-typescript" "master" "typescript/src")
         (yaml "https://github.com/ikatyang/tree-sitter-yaml")))
 
-(defun my-compile-treesit-grammars ()
+(defun omegamacs-compile-treesit-grammars ()
   "Compile all tree-sitter grammars defined in `treesit-language-source-alist'."
   (interactive)
   (dolist (lang treesit-language-source-alist)
@@ -139,15 +139,15 @@ Potential side effects:
 
 ;; LSP performance optimizations
 ;; Increase GC threshold to 100MB to reduce garbage collection frequency during LSP operations.
-(defconst my/gc-cons-threshold 100000000
+(defconst omegamacs/gc-cons-threshold 100000000
   "Garbage collection threshold set to 100MB for improved LSP performance.")
-(setq gc-cons-threshold my/gc-cons-threshold)
+(setq gc-cons-threshold omegamacs/gc-cons-threshold)
 (setq read-process-output-max (* 1024 1024 4)) ;; 4 MB
 
 ;; Yasnippet for code snippets
 (use-package yasnippet
   :ensure t
-  :defer my-enable-lazy-loading
+  :defer omegamacs-enable-lazy-loading
   :hook ((prog-mode . yas-minor-mode)
          (text-mode . yas-minor-mode))
   :config
@@ -160,13 +160,13 @@ Potential side effects:
 ;; Common snippets collection
 (use-package yasnippet-snippets
   :ensure t
-  :defer my-enable-lazy-loading
+  :defer omegamacs-enable-lazy-loading
   :after yasnippet)
 
 ;; Indentation visualization with highlight-indent-guides
 (use-package highlight-indent-guides
   :ensure t
-  :defer my-enable-lazy-loading
+  :defer omegamacs-enable-lazy-loading
   :hook ((prog-mode . highlight-indent-guides-mode)
          (yaml-mode . highlight-indent-guides-mode)
          (verilog-mode . highlight-indent-guides-mode)
@@ -203,7 +203,7 @@ Potential side effects:
 
 (use-package imenu-list
   :ensure t
-  :defer my-enable-lazy-loading
+  :defer omegamacs-enable-lazy-loading
   :commands (imenu-list-smart-toggle imenu-list-minor-mode)
   :config
   (setq imenu-list-auto-resize t
@@ -215,17 +215,17 @@ Potential side effects:
 
 (use-package flycheck-pos-tip
   :ensure t
-  :defer my-enable-lazy-loading
+  :defer omegamacs-enable-lazy-loading
   :after flycheck)
 
 (use-package dap-mode
   :ensure t
-  :defer my-enable-lazy-loading
+  :defer omegamacs-enable-lazy-loading
   :after lsp-mode)
 
 (use-package realgud
   :ensure t
-  :defer my-enable-lazy-loading
+  :defer omegamacs-enable-lazy-loading
   :after (lsp-mode dap-mode)
   :config
   ;; Use realgud for debugging
@@ -236,10 +236,10 @@ Potential side effects:
 
 (use-package realgud-ipdb
   :ensure t
-  :defer my-enable-lazy-loading
+  :defer omegamacs-enable-lazy-loading
   :after realgud)
 
 (use-package realgud-lldb
   :ensure t
-  :defer my-enable-lazy-loading
+  :defer omegamacs-enable-lazy-loading
   :after realgud)

--- a/projectile.el
+++ b/projectile.el
@@ -3,7 +3,7 @@
 ;; Projectile mode
 (use-package projectile
   :ensure t
-  :defer my-enable-lazy-loading
+  :defer omegamacs-enable-lazy-loading
   :bind-keymap ("C-c p" . projectile-command-map)
   :config
   (projectile-mode)
@@ -11,8 +11,8 @@
   (setq projectile-indexing-method 'alien)
   ;; Use git ls-files when in git repo, fallback to find for non-git projects
   (setq projectile-generic-command
-        (if my-settings-projectile-generic-command
-            my-settings-projectile-generic-command
+        (if omegamacs-settings-projectile-generic-command
+            omegamacs-settings-projectile-generic-command
             "git ls-files -zco --exclude-standard 2>/dev/null || find . -type f -print0"))
   (setq projectile-sort-order 'recently-active)
 
@@ -20,7 +20,7 @@
   (setq projectile-completion-system 'default))
 
 ;; Custom function to copy current file path relative to project root to clipboard
-(defun my-copy-file-path-from-project-root ()
+(defun omegamacs-copy-file-path-from-project-root ()
   "Copy the current file's path relative to project root to clipboard."
   (interactive)
   (when buffer-file-name
@@ -34,9 +34,9 @@
       (message "Copied to clipboard: %s" relative-path))))
 
 ;; Bind to a convenient key combination
-(global-set-key (kbd "C-c f p") 'my-copy-file-path-from-project-root)
+(global-set-key (kbd "C-c f p") 'omegamacs-copy-file-path-from-project-root)
 
 (use-package treemacs-projectile
   :ensure t
-  :defer my-enable-lazy-loading
+  :defer omegamacs-enable-lazy-loading
   :after (treemacs projectile))

--- a/settings.el
+++ b/settings.el
@@ -17,20 +17,20 @@
 ;(add-to-list 'default-frame-alist '(font . "-unknown-DejaVu Sans Mono-normal-normal-normal-*-13-*-*-*-*-*-*-*"))
 
 ;; Color settings
-(defun my--set-colors ()
+(defun omegamacs--set-colors ()
   (set-background-color "gray20")
   (set-cursor-color "cyan")
   (set-foreground-color "gray80"))
 
-(defun my--set-frame-colors (frame)
+(defun omegamacs--set-frame-colors (frame)
   (select-frame frame)
   (set-background-color "gray20")
   (set-cursor-color "cyan")
   (set-foreground-color "gray80"))
 
 (if (daemonp)
-	(add-hook 'after-make-frame-functions #'my--set-frame-colors)
-  (my--set-colors))
+	(add-hook 'after-make-frame-functions #'omegamacs--set-frame-colors)
+  (omegamacs--set-colors))
 
 ;;Use space not tabs
 (setq-default indent-tabs-mode nil)
@@ -55,15 +55,15 @@
 (global-hl-line-mode t) ; turn it on for all modes by default
 
 ;; Zoom text
-(defun my-text-zoom (n)
+(defun omegamacs-text-zoom (n)
   "with positive N, increase the font size, otherwise decrease it"
   (set-face-attribute 'default (selected-frame) :height
     (+ (face-attribute 'default :height) (* (if (> n 0) 1 -1) 10))))
 
-(global-set-key (kbd "C-+")      #'(lambda nil (interactive) (my-text-zoom 1)))
-(global-set-key [C-kp-add]       #'(lambda nil (interactive) (my-text-zoom 1)))
-(global-set-key (kbd "C--")      #'(lambda nil (interactive) (my-text-zoom -1)))
-(global-set-key [C-kp-subtract]  #'(lambda nil (interactive) (my-text-zoom -1)))
+(global-set-key (kbd "C-+")      #'(lambda nil (interactive) (omegamacs-text-zoom 1)))
+(global-set-key [C-kp-add]       #'(lambda nil (interactive) (omegamacs-text-zoom 1)))
+(global-set-key (kbd "C--")      #'(lambda nil (interactive) (omegamacs-text-zoom -1)))
+(global-set-key [C-kp-subtract]  #'(lambda nil (interactive) (omegamacs-text-zoom -1)))
 
 (defhydra hydra-zoom (:color pink :hint nil)
   "
@@ -82,7 +82,7 @@
        (set-face-background 'smerge-refined-change "dark magenta")))
 
 ;; Keep backups in a dedicated folder
-(let ((backup-dir (my-user-emacs-subdirectory-local "backups")))
+(let ((backup-dir (omegamacs-user-emacs-subdirectory-local "backups")))
   (setq backup-directory-alist (list (cons "." backup-dir))
         backup-by-copying t
         delete-old-versions t

--- a/templates/early-init.el
+++ b/templates/early-init.el
@@ -1,9 +1,9 @@
 ;; This can be good to set to a disk local location if your ${HOME} is mounted via NFS to speed up certain file operations
 ;; For example:
-;; (setq my-user-emacs-directory-local "/path/to/local/disk/.emacs.d.local")
-(setq my-user-emacs-directory-local user-emacs-directory)
+;; (setq omegamacs-user-emacs-directory-local "/path/to/local/disk/.emacs.d.local")
+(setq omegamacs-user-emacs-directory-local user-emacs-directory)
 
 (when (and (fboundp 'startup-redirect-eln-cache)
            (fboundp 'native-comp-available-p)
            (native-comp-available-p))
-  (startup-redirect-eln-cache (convert-standard-filename (expand-file-name "eln-cache/" my-user-emacs-directory-local))))
+  (startup-redirect-eln-cache (convert-standard-filename (expand-file-name "eln-cache/" omegamacs-user-emacs-directory-local))))

--- a/templates/init.el
+++ b/templates/init.el
@@ -8,40 +8,40 @@
 ;;;   --no-defer  : Disable lazy loading (load all packages immediately)
 
 ;;; Emacs configuration root directory
-;; (setq my-emacs-config-dir "~/omegamacs")
+;; (setq omegamacs-emacs-config-dir "~/omegamacs")
 
 ;;; Local data directory (set in early-init.el if needed for performance)
-;; Ensure my-user-emacs-directory-local is set to default if not configured
-(unless (boundp 'my-user-emacs-directory-local)
-  (setq my-user-emacs-directory-local user-emacs-directory))
+;; Ensure omegamacs-user-emacs-directory-local is set to default if not configured
+(unless (boundp 'omegamacs-user-emacs-directory-local)
+  (setq omegamacs-user-emacs-directory-local user-emacs-directory))
 
 ;;; Personal settings
 ;; Suppress startup echo area message - replace "your-username" with your actual username
 ;; (setq inhibit-startup-echo-area-message "your-username")
 
 ;;; helm-jira settings
-;; (setq my-settings-jira-url      "url to JIRA project")
-;; (setq my-settings-jira-username "JIRA user")
-;; (setq my-settings-jira-project  "JIRA project name")
+;; (setq omegamacs-settings-jira-url      "url to JIRA project")
+;; (setq omegamacs-settings-jira-username "JIRA user")
+;; (setq omegamacs-settings-jira-project  "JIRA project name")
 
 ;;; Copilot configuration
 ;; Set to 'none, 'setup, or 'full to control Copilot loading
 ;; none: No Copilot support
 ;; setup: Minimal Copilot setup for initial server installation and authentication
 ;; full: Complete Copilot configuration with all features
-;; (setq my-copilot-config 'none)
+;; (setq omegamacs-copilot-config 'none)
 
 ;;; Projectile
-;; (setq my-settings-projectile-generic-command "find . -type f -not -wholename '*some_folder_to_filter/*' -not -wholename '*some_other_folder_to_filter/*' -print0")
+;; (setq omegamacs-settings-projectile-generic-command "find . -type f -not -wholename '*some_folder_to_filter/*' -not -wholename '*some_other_folder_to_filter/*' -print0")
 
 ;; Un-comment and set to use a specific shell history file
-;; (setq my-compile-mode-shell-history-file (getenv "HISTFILE"))
+;; (setq omegamacs-compile-mode-shell-history-file (getenv "HISTFILE"))
 ;; Or set to a specific file path:
-;; (setq my-compile-mode-shell-history-file "~/.bash_history")
+;; (setq omegamacs-compile-mode-shell-history-file "~/.bash_history")
 ;; If left unset the history file will be guessed
 
 ;; Configuration variables for shell history integration into compile mode
-(defvar my-compile-mode-shell-history-size 100
+(defvar omegamacs-compile-mode-shell-history-size 100
   "Control how many lines of shell history to read into compile mode.
 nil: never read shell history
 0: read full shell history
@@ -49,6 +49,6 @@ nil: never read shell history
 
 
 ;; Load main configuration from the configured directory
-(let ((config-dir (or (and (boundp 'my-emacs-config-dir) my-emacs-config-dir)
+(let ((config-dir (or (and (boundp 'omegamacs-emacs-config-dir) omegamacs-emacs-config-dir)
                       "~/omegamacs")))  ; Default fallback
   (load-file (expand-file-name "emacs_init.el" config-dir)))

--- a/tramp.el
+++ b/tramp.el
@@ -90,15 +90,15 @@
   (setq tramp-default-method "ssh"          ; SSH as default (more secure than scp)
         tramp-verbose 1                      ; Minimal verbosity (increase to 6 for debugging)
         tramp-use-ssh-controlmaster-options t ; Use SSH ControlMaster for connection reuse
-        tramp-persistency-file-name (my-user-emacs-subdirectory-local "cache/tramp") ; Persist connection data
+        tramp-persistency-file-name (omegamacs-user-emacs-subdirectory-local "cache/tramp") ; Persist connection data
         tramp-completion-reread-directory-timeout nil ; Disable to improve performance
-        tramp-auto-save-directory (my-user-emacs-subdirectory-local "tramp-auto-save") ; Separate auto-save dir
+        tramp-auto-save-directory (omegamacs-user-emacs-subdirectory-local "tramp-auto-save") ; Separate auto-save dir
         remote-file-name-inhibit-cache nil   ; Enable caching (set to t to disable for fresh data)
         vc-ignore-dir-regexp (format "%s\\|%s" vc-ignore-dir-regexp tramp-file-name-regexp) ; Disable VC for TRAMP
         tramp-chunksize 8192)                ; Optimize chunk size for better performance
 
   ;; Create TRAMP directories if they don't exist
-  (dolist (dir (list (my-user-emacs-subdirectory-local "tramp-auto-save")
+  (dolist (dir (list (omegamacs-user-emacs-subdirectory-local "tramp-auto-save")
                      (file-name-directory tramp-persistency-file-name)))
     (unless (file-directory-p dir)
       (make-directory dir t)))
@@ -112,17 +112,17 @@
 
   ;; Backup configuration for remote files
   (add-to-list 'backup-directory-alist
-               (cons tramp-file-name-regexp (my-user-emacs-subdirectory-local "tramp-backups")))
-  ;; Directory creation is handled by my-user-emacs-subdirectory-local function
-  (my-user-emacs-subdirectory-local "tramp-backups")
+               (cons tramp-file-name-regexp (omegamacs-user-emacs-subdirectory-local "tramp-backups")))
+  ;; Directory creation is handled by omegamacs-user-emacs-subdirectory-local function
+  (omegamacs-user-emacs-subdirectory-local "tramp-backups")
 
   ;; Performance: Disable version control for remote files
-  (defun my--tramp-disable-vc (orig-fun &rest args)
+  (defun omegamacs--tramp-disable-vc (orig-fun &rest args)
     "Disable version control for TRAMP files to improve performance."
     (if (file-remote-p default-directory)
         nil
       (apply orig-fun args)))
-  (advice-add 'vc-backend :around #'my--tramp-disable-vc)
+  (advice-add 'vc-backend :around #'omegamacs--tramp-disable-vc)
 
   ;; Security: Prompt for passwords instead of storing them
   (setq password-cache-expiry 300           ; Cache passwords for 5 minutes
@@ -170,11 +170,11 @@
       :category tramp-host
       :face     consult-file
       :history  file-name-history
-      :items    ,#'my--tramp-host-candidates
-      :action   ,#'my--tramp-open-host)
+      :items    ,#'omegamacs--tramp-host-candidates
+      :action   ,#'omegamacs--tramp-open-host)
     "TRAMP host candidate source for `consult-buffer'.")
 
-  (defun my--tramp-host-candidates ()
+  (defun omegamacs--tramp-host-candidates ()
     "Return list of TRAMP host candidates from SSH config and known hosts."
     (let ((hosts '())
           (ssh-config (expand-file-name "~/.ssh/config"))
@@ -200,7 +200,7 @@
                 (push (format "/ssh:%s:" host) hosts))))))
       (delete-dups hosts)))
 
-  (defun my--tramp-open-host (host)
+  (defun omegamacs--tramp-open-host (host)
     "Open TRAMP connection to HOST."
     (find-file host))
 
@@ -225,7 +225,7 @@
           consult--source-tramp-host))
 
   ;; Custom function to show buffers without TRAMP hosts
-  (defun my-consult-buffer-no-tramp ()
+  (defun omegamacs-consult-buffer-no-tramp ()
     "Show consult-buffer without TRAMP host candidates."
     (interactive)
     (let ((consult-buffer-sources
@@ -250,14 +250,14 @@
     "TRAMP buffer candidate source for `consult-buffer'.")
 
   ;; Function to toggle TRAMP sources in buffer list
-  (defvar my-tramp-sources-enabled t
+  (defvar omegamacs-tramp-sources-enabled t
     "Whether TRAMP sources are shown in consult-buffer.")
 
-  (defun my-toggle-tramp-in-buffer-list ()
+  (defun omegamacs-toggle-tramp-in-buffer-list ()
     "Toggle display of TRAMP sources in consult-buffer."
     (interactive)
-    (setq my-tramp-sources-enabled (not my-tramp-sources-enabled))
-    (if my-tramp-sources-enabled
+    (setq omegamacs-tramp-sources-enabled (not omegamacs-tramp-sources-enabled))
+    (if omegamacs-tramp-sources-enabled
         (progn
           (add-to-list 'consult-buffer-sources 'consult--source-tramp-host t)
           (add-to-list 'consult-buffer-sources 'consult--source-tramp-buffer t)
@@ -268,7 +268,7 @@
       (message "TRAMP sources disabled in buffer list"))))
 
 ;; Enhanced TRAMP commands with Vertico completion
-(defun my-tramp-cleanup-all ()
+(defun omegamacs-tramp-cleanup-all ()
   "Clean up all TRAMP connections and buffers."
   (interactive)
   (when (y-or-n-p "Clean up all TRAMP connections? ")
@@ -276,7 +276,7 @@
     (tramp-cleanup-all-buffers)
     (message "All TRAMP connections cleaned up")))
 
-(defun my-tramp-cleanup-current ()
+(defun omegamacs-tramp-cleanup-current ()
   "Clean up TRAMP connection for current buffer."
   (interactive)
   (when (file-remote-p default-directory)
@@ -284,7 +284,7 @@
       (tramp-cleanup-connection vec)
       (message "Cleaned up connection to %s" (tramp-make-tramp-file-name vec)))))
 
-(defun my-tramp-reopen-current ()
+(defun omegamacs-tramp-reopen-current ()
   "Reopen current file after cleaning up its TRAMP connection."
   (interactive)
   (when (and (file-remote-p default-directory)
@@ -292,12 +292,12 @@
     (let ((file buffer-file-name)
           (line (line-number-at-pos))
           (col (current-column)))
-      (my-tramp-cleanup-current)
+      (omegamacs-tramp-cleanup-current)
       (find-file file)
       (goto-line line)
       (move-to-column col))))
 
-(defun my-tramp-sudo-find-file (file)
+(defun omegamacs-tramp-sudo-find-file (file)
   "Open FILE with sudo via TRAMP."
   (interactive "FFind file (sudo): ")
   (find-file (if (file-remote-p file)
@@ -315,50 +315,50 @@
 ;; Projectile integration for TRAMP
 (with-eval-after-load 'projectile
   ;; Optimize projectile for TRAMP
-  (defun my--projectile-project-root-tramp (orig-fn &rest args)
+  (defun omegamacs--projectile-project-root-tramp (orig-fn &rest args)
     "Optimize project root detection for TRAMP files."
     (if (file-remote-p default-directory)
         (let ((projectile-git-command "git ls-files -zco --exclude-standard")
               (projectile-generic-command "find . -type f -print0"))
           (apply orig-fn args))
       (apply orig-fn args)))
-  (advice-add 'projectile-project-root :around #'my--projectile-project-root-tramp))
+  (advice-add 'projectile-project-root :around #'omegamacs--projectile-project-root-tramp))
 
 ;; Magit integration for TRAMP
 (with-eval-after-load 'magit
   ;; Improve magit performance over TRAMP
-  (defun my--magit-process-environment (env)
+  (defun omegamacs--magit-process-environment (env)
     "Add TRAMP-friendly environment settings to magit."
     (cons "GIT_PAGER=cat" env))
-  (advice-add 'magit-process-environment :filter-return #'my--magit-process-environment)
+  (advice-add 'magit-process-environment :filter-return #'omegamacs--magit-process-environment)
 
   ;; Disable certain magit features for remote repos
-  (defun my--magit-disable-for-tramp ()
+  (defun omegamacs--magit-disable-for-tramp ()
     "Disable certain magit features when in TRAMP buffer."
     (when (file-remote-p default-directory)
       (setq-local magit-refresh-verbose t)
       (setq-local magit-git-executable "git")
       (setq-local auto-revert-mode nil)))
-  (add-hook 'magit-mode-hook #'my--magit-disable-for-tramp))
+  (add-hook 'magit-mode-hook #'omegamacs--magit-disable-for-tramp))
 
 ;; Key bindings
-(global-set-key (kbd "C-c t c") #'my-tramp-cleanup-current)
-(global-set-key (kbd "C-c t C") #'my-tramp-cleanup-all)
-(global-set-key (kbd "C-c t r") #'my-tramp-reopen-current)
-(global-set-key (kbd "C-c t s") #'my-tramp-sudo-find-file)
+(global-set-key (kbd "C-c t c") #'omegamacs-tramp-cleanup-current)
+(global-set-key (kbd "C-c t C") #'omegamacs-tramp-cleanup-all)
+(global-set-key (kbd "C-c t r") #'omegamacs-tramp-reopen-current)
+(global-set-key (kbd "C-c t s") #'omegamacs-tramp-sudo-find-file)
 (global-set-key (kbd "C-c t h") #'(lambda () (interactive)
                                     (consult-buffer '(consult--source-tramp-host))))
-(global-set-key (kbd "C-c t b") #'my-consult-buffer-no-tramp)
-(global-set-key (kbd "C-c t t") #'my-toggle-tramp-in-buffer-list)
+(global-set-key (kbd "C-c t b") #'omegamacs-consult-buffer-no-tramp)
+(global-set-key (kbd "C-c t t") #'omegamacs-toggle-tramp-in-buffer-list)
 
 ;; Debugging helpers
-(defun my-tramp-toggle-debug ()
+(defun omegamacs-tramp-toggle-debug ()
   "Toggle TRAMP debugging."
   (interactive)
   (setq tramp-verbose (if (= tramp-verbose 1) 6 1))
   (message "TRAMP verbosity set to %d" tramp-verbose))
 
-(global-set-key (kbd "C-c t d") #'my-tramp-toggle-debug)
+(global-set-key (kbd "C-c t d") #'omegamacs-tramp-toggle-debug)
 
 ;; Auto-cleanup idle connections
 (run-with-idle-timer 3600 t #'tramp-cleanup-all-connections)


### PR DESCRIPTION
## Summary
• Replaced all `my-` prefixes with `omegamacs-` throughout the entire codebase
• Updated function names, variables, configuration settings, and internal utilities

## Test Plan
- [x] Configuration loads without errors
- [x] All functions maintain same functionality
- [ ] No remaining `my-` prefixes in codebase